### PR TITLE
fix: require T: Copy in Chomp to prevent double-free

### DIFF
--- a/src/chomp.rs
+++ b/src/chomp.rs
@@ -1,20 +1,25 @@
 #[derive(Clone, Copy)]
 pub struct Chomp<T>(pub(crate) *const T);
 
-impl<T> Chomp<T> {
+impl<T: Copy> Chomp<T> {
     pub fn new(value: &T) -> Self {
         Self(value as *const _)
     }
+    /// # Safety
+    /// 
+    /// This method reads the value from the raw pointer. Since `T: Copy`,
+    /// this is a bitwise copy operation, not a move. The original value
+    /// remains valid after this call, preventing double-free UB.
     pub fn inner(&self) -> T {
         unsafe { std::ptr::read_unaligned(self.0) }
     }
 }
 
-pub trait ChompFlatten<T> {
+pub trait ChompFlatten<T: Copy> {
     fn flatten(&self) -> Vec<T>;
 }
 
-impl<T> ChompFlatten<T> for Vec<Chomp<T>> {
+impl<T: Copy> ChompFlatten<T> for Vec<Chomp<T>> {
     fn flatten(&self) -> Vec<T> {
         self.iter().map(|c| c.inner()).collect()
     }


### PR DESCRIPTION
## Summary

`Chomp::inner()` uses `ptr::read_unaligned` which moves the value out of the raw pointer. For owned types like `Box<T>`, this causes a double-free when the original value is dropped.

## PoC

```rust
let box_val = Box::new(5);
let chomp = Chomp::new(&box_val);
let copied = chomp.inner(); // moves the Box out
// box_val is now dropped, freeing the same memory -> double-free!
```

## Fix

Add `T: Copy` bound to `Chomp<T>`, `Chomp::new()`, `Chomp::inner()`, and `ChompFlatten`. This ensures `inner()` performs a bitwise copy rather than a move, keeping the original value valid.

## References

- Issue #5: https://github.com/KingPEPSALT/bitchomp/issues/5
- RUSTSEC-2026-0131